### PR TITLE
conf: replace travis-ci with github

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,10 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # 'bundle install' and cache
+    - name: Start MongoDB
+      uses: supercharge/mongodb-github-action@1.7.0
+      with:
+        mongodb-version: '4.4'
     - name: Run tests
       run: bundle exec rake
     - name: Coveralls

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+# Download the latest Ruby patch versions, install dependencies, and run tests.
+name: test
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+jobs:
+  test:
+    environment: staging
+    runs-on: ubuntu-latest
+    name: Ruby ${{ matrix.ruby-version }}
+    strategy:
+      matrix:
+        ruby-version: [2.5, 2.6, 2.7, '3.0']
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Set up Ruby ${{ matrix.ruby-version }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # 'bundle install' and cache
+    - name: Run tests
+      run: bundle exec rake
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Rubocop
+      run: bundle exec rubocop

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'simplecov-lcov'
+
+SimpleCov::Formatter::LcovFormatter.config do |c|
+  c.report_with_single_file = true
+  c.single_report_path = 'coverage/lcov.info'
+end
+SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(
+  [
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::LcovFormatter
+  ]
+)
+SimpleCov.start

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-sudo: false
-rvm:
-  - 2.2.2
-script:
-  - bundle exec rake
-  - bundle exec rubocop
-services: mongodb

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HitCounter
 
-[![Travis CI](https://secure.travis-ci.org/ivanoblomov/hit_counter.png)](https://travis-ci.org/ivanoblomov/hit_counter)
+![Build status](https://github.com/ivanoblomov/hit_counter/workflows/test/badge.svg)
 [![Code Climate](https://codeclimate.com/github/ivanoblomov/hit_counter.png)](https://codeclimate.com/github/ivanoblomov/hit_counter)
 [![Coveralls](https://coveralls.io/repos/ivanoblomov/hit_counter/badge.svg?branch=master&service=github)](https://coveralls.io/github/ivanoblomov/hit_counter?branch=master)
 [![Dependency Status](https://gemnasium.com/ivanoblomov/hit_counter.png)](https://gemnasium.com/ivanoblomov/hit_counter)

--- a/hit_counter.gemspec
+++ b/hit_counter.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '< 1.24'
   s.add_development_dependency 'rubocop-rake', '~> 0'
   s.add_development_dependency 'rubocop-rspec', '~> 2'
+  s.add_development_dependency 'simplecov', '~> 0.18'
+  s.add_development_dependency 'simplecov-lcov', '~> 0.8'
 
   s.add_runtime_dependency 'addressable', '~> 2'
   s.add_runtime_dependency 'bson_ext', '~> 1'

--- a/hit_counter.gemspec
+++ b/hit_counter.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/ivanoblomov/hit_counter'
   s.authors = ['Roderick Monje']
 
-  s.add_development_dependency 'coveralls', '~> 0'
   s.add_development_dependency 'rake', '>= 12.3.3', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rubocop', '< 1.24'

--- a/hit_counter.gemspec
+++ b/hit_counter.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'addressable', '~> 2'
   s.add_runtime_dependency 'bson_ext', '~> 1'
-  s.add_runtime_dependency 'mongoid', '~> 6'
+  s.add_runtime_dependency 'mongoid', '~> 7'
   s.add_runtime_dependency 'rmagick', '~> 2'
 
   s.files         = `git ls-files`.split "\n"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 require 'simplecov'
-SimpleCov.start
-require 'coveralls'
-Coveralls.wear!
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  Coveralls::SimpleCov::Formatter
-]
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'addressable/uri'


### PR DESCRIPTION
Closes: #6

# Goal
Migrate to CI GitHub Actions.

# Approach
1. Add Action `workflows/test.yml`.
2. Delete Travis CI files and replace badge.
3. Configure CI's MongoDB.
4. Replace Coveralls with SimpleCov.
5. Bump Mongoid for Ruby 3 compatibility.

Signed-off-by: Roderick Monje <rod@foveacentral.com>
